### PR TITLE
Add distressed land finder CLI for Florida auction sourcing

### DIFF
--- a/distressed_land_finder/README.md
+++ b/distressed_land_finder/README.md
@@ -1,0 +1,82 @@
+# Florida Distressed Land Finder
+
+This toolkit pulls together IRS seizure auctions and Florida county tax deed or lien offerings hosted on Bid4Assets so you can zero-in on inexpensive commercial or vacant land opportunities. It is designed for terminal environments such as [iSH](https://ish.app/) on iOS and can export leads into CSVs for additional due diligence workflows.
+
+## Features
+
+- Aggregates two high-value sources:
+  - **IRS Seized Real Estate** – scrapes the Treasury auction site for Florida listings, including sale date, deposit and property notes.
+  - **Bid4Assets** – extracts Florida county tax deed / tax lien auctions that commonly arise from delinquent property taxes.
+- Normalizes listings into a single schema with acreage, minimum bid, sale date, location, status and descriptive tags.
+- Ranks leads with a scoring model that favors low minimum bids, larger acreage, commercial designations and imminent sale dates.
+- Powerful filtering options (price ceilings, minimum acreage, county whitelists, sale type or keyword filtering).
+- Optional interactive inspection mode for drilling into the highest-ranked properties without leaving the terminal.
+- Caching layer to avoid re-downloading large listing pages during repeated runs.
+- Bundled demo dataset for offline experimentation.
+
+## Installation
+
+1. Ensure Python 3.10+ is available in your iSH or Linux environment (`python3 --version`).
+2. Install dependencies (recommended inside a virtual environment):
+
+   ```bash
+   pip install requests beautifulsoup4 python-dateutil rich
+   ```
+
+   The tool gracefully falls back to plain-text tables when `rich` is not installed, but `rich` provides a nicer TUI experience.
+
+3. Copy the `distressed_land_finder` directory to your working project or keep it inside this repository.
+
+## Quick start
+
+Run the CLI directly from the repository root:
+
+```bash
+python -m distressed_land_finder.cli --demo
+```
+
+The `--demo` flag loads bundled sample listings so you can explore the interface without hitting live endpoints.
+
+To fetch real-time Florida opportunities (requires internet access):
+
+```bash
+python -m distressed_land_finder.cli --max-price 200000 --min-acreage 0.5 --counties "Duval,Miami-Dade"
+```
+
+### Useful flags
+
+- `--max-price` – Filter out listings whose minimum bid exceeds the specified dollar amount.
+- `--min-acreage` – Require listings to meet a minimum acreage threshold.
+- `--counties` – Focus on specific Florida counties (comma separated).
+- `--tags` – Require tags such as `IRS`, `Tax Deed`, or `Commercial` to be present.
+- `--sources` – Choose between `irs` and `bid4assets` connectors (e.g. `--sources irs`).
+- `--export leads.csv` – Export the filtered list into a CSV for use in spreadsheets or CRM tools.
+- `--interactive` – After displaying the top leads, drop into a prompt where you can type the row number to see detailed information.
+- `--skip-cache` – Force refresh of every source instead of using cached pages.
+
+### Interactive mode commands
+
+When running with `--interactive`, enter the numeric row ID to view the full record, or type `q` to exit.
+
+## How it works
+
+1. Each source implementation (see `sources/irs.py` and `sources/bid4assets.py`) downloads and parses the respective provider's public listings.
+2. Listings are normalized into a shared data structure (`PropertyListing`) so they can be filtered and ranked uniformly.
+3. The scoring engine prioritizes low-cost, land-centric, commercial and soon-to-expire opportunities, producing a sortable score.
+4. Results are presented via `rich` tables or plain text and can optionally be exported to CSV.
+
+## Extending the toolkit
+
+- Add new connectors by subclassing the pattern in `distressed_land_finder/sources/` and registering them in `SOURCES_REGISTRY` inside `cli.py`.
+- Adjust the scoring heuristics in `filters.py` if you prefer different weighting (e.g., favoring acreage over bid price).
+- Create cron jobs or launch agents that run the CLI with `--export` to keep a rolling CSV of upcoming auctions.
+
+## Troubleshooting
+
+- **403 or 503 HTTP errors** – Some auction platforms apply rate limits or block unknown user agents. The bundled `HttpClient` already spoofs a desktop browser, but you may still need to rerun or add your own headers / proxies via code modifications.
+- **No listings returned** – Check internet connectivity, confirm the site has active auctions, or run with `--verbose` to see diagnostic logs.
+- **Certificate issues on iSH** – Install `ca-certificates` within Alpine (`apk add ca-certificates`) and rerun.
+
+## License
+
+This folder is distributed under the same license as the parent repository. Please respect each data source's terms of service and confirm auction details with the respective county or federal agency before bidding.

--- a/distressed_land_finder/__init__.py
+++ b/distressed_land_finder/__init__.py
@@ -1,0 +1,5 @@
+"""Florida distressed land finder package."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/distressed_land_finder/__main__.py
+++ b/distressed_land_finder/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/distressed_land_finder/cache.py
+++ b/distressed_land_finder/cache.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class CacheEntry:
+    value: Any
+    expires_at: Optional[float]
+
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return self.expires_at < time.time()
+
+
+class CacheManager:
+    """Simple JSON-backed cache for HTTP sources."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._entries: Dict[str, CacheEntry] = {}
+        if path.exists():
+            try:
+                data = json.loads(path.read_text())
+            except json.JSONDecodeError:
+                data = {}
+            for key, payload in data.items():
+                self._entries[key] = CacheEntry(
+                    value=payload.get("value"),
+                    expires_at=payload.get("expires_at"),
+                )
+
+    def get(self, key: str) -> Optional[Any]:
+        entry = self._entries.get(key)
+        if not entry:
+            return None
+        if entry.is_expired():
+            del self._entries[key]
+            return None
+        return entry.value
+
+    def set(self, key: str, value: Any, ttl: int = 3600) -> None:
+        expires_at = time.time() + ttl if ttl else None
+        self._entries[key] = CacheEntry(value=value, expires_at=expires_at)
+
+    def save(self) -> None:
+        if not self.path.parent.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        serialized: Dict[str, Dict[str, Any]] = {}
+        for key, entry in self._entries.items():
+            expires_at: Optional[float]
+            if entry.expires_at is None:
+                expires_at = None
+            else:
+                expires_at = entry.expires_at
+            serialized[key] = {
+                "value": entry.value,
+                "expires_at": expires_at,
+            }
+        self.path.write_text(json.dumps(serialized, indent=2, sort_keys=True))

--- a/distressed_land_finder/cli.py
+++ b/distressed_land_finder/cli.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .cache import CacheManager
+from .display import describe_listing, render
+from .filters import FilterCriteria, apply_filters, score_listings
+from .sources.base import PropertyListing
+
+MISSING_CONNECTORS: Dict[str, str] = {}
+
+try:  # pragma: no cover - depends on optional dependency
+    from .sources.bid4assets import Bid4AssetsFloridaSource
+except ModuleNotFoundError as exc:  # pragma: no cover
+    Bid4AssetsFloridaSource = None  # type: ignore
+    MISSING_CONNECTORS["bid4assets"] = (
+        "Bid4Assets connector requires BeautifulSoup (pip install beautifulsoup4)."
+    )
+
+try:  # pragma: no cover - depends on optional dependency
+    from .sources.irs import IRSRealEstateSource
+except ModuleNotFoundError as exc:  # pragma: no cover
+    IRSRealEstateSource = None  # type: ignore
+    MISSING_CONNECTORS["irs"] = "IRS connector requires BeautifulSoup (pip install beautifulsoup4)."
+
+SOURCES_REGISTRY = {
+    slug: source
+    for slug, source in {
+        (getattr(IRSRealEstateSource, "slug", "irs")): IRSRealEstateSource,
+        (getattr(Bid4AssetsFloridaSource, "slug", "bid4assets")): Bid4AssetsFloridaSource,
+    }.items()
+    if source is not None
+}
+
+
+def _load_demo_listings() -> List[PropertyListing]:
+    demo_path = Path(__file__).resolve().parent / "demo_data" / "demo_listings.json"
+    if not demo_path.exists():
+        raise FileNotFoundError("Demo data file missing; reinstall the package or fetch real data.")
+    payload = json.loads(demo_path.read_text())
+    listings = [PropertyListing.from_dict(item) for item in payload]
+    return listings
+
+
+def _load_cached_listings(cache: CacheManager, source_key: str) -> List[PropertyListing]:
+    cached = cache.get(source_key)
+    if not cached:
+        return []
+    try:
+        return [PropertyListing.from_dict(item) for item in cached]
+    except Exception:
+        return []
+
+
+def _store_cache(cache: CacheManager, source_key: str, listings: Iterable[PropertyListing], ttl: int) -> None:
+    payload = [listing.to_dict() for listing in listings]
+    cache.set(source_key, payload, ttl=ttl)
+
+
+def fetch_all_sources(selected_sources: Iterable[str], *, cache: CacheManager, ttl: int, use_cache: bool) -> List[PropertyListing]:
+    listings: List[PropertyListing] = []
+    for slug in selected_sources:
+        source_cls = SOURCES_REGISTRY.get(slug)
+        if not source_cls:
+            message = MISSING_CONNECTORS.get(slug)
+            if message:
+                logging.warning("%s", message)
+            else:
+                logging.warning("Unknown source '%s'", slug)
+            continue
+        cache_key = f"source::{slug}"
+        if use_cache:
+            cached_listings = _load_cached_listings(cache, cache_key)
+            if cached_listings:
+                logging.info("Loaded %d cached listings from %s", len(cached_listings), slug)
+                listings.extend(cached_listings)
+                continue
+        source = source_cls()
+        fresh_listings = list(source.fetch_listings())
+        logging.info("Fetched %d listings from %s", len(fresh_listings), source.title)
+        if fresh_listings:
+            listings.extend(fresh_listings)
+            _store_cache(cache, cache_key, fresh_listings, ttl)
+    cache.save()
+    return listings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Discover Florida distressed land opportunities from IRS seizures and county tax deed auctions.",
+    )
+    parser.add_argument("--max-price", type=float, help="Maximum minimum-bid amount to include.")
+    parser.add_argument("--min-acreage", type=float, help="Minimum acreage to include.")
+    parser.add_argument(
+        "--counties",
+        type=lambda value: [item.strip() for item in value.split(",") if item.strip()],
+        help="Comma-separated list of Florida counties to include.",
+    )
+    parser.add_argument(
+        "--sale-types",
+        type=lambda value: [item.strip() for item in value.split(",") if item.strip()],
+        help="Only include sale types that match any of the provided values.",
+    )
+    parser.add_argument(
+        "--tags",
+        type=lambda value: [item.strip() for item in value.split(",") if item.strip()],
+        help="Require at least one of these tags (e.g. IRS, Tax Deed).",
+    )
+    parser.add_argument(
+        "--keywords",
+        type=lambda value: [item.strip() for item in value.split(",") if item.strip()],
+        help="Require keywords to appear in the title/location/description.",
+    )
+    parser.add_argument(
+        "--sources",
+        default="irs,bid4assets",
+        help="Comma-separated list of sources to query (irs,bid4assets).",
+    )
+    parser.add_argument("--limit", type=int, default=20, help="Number of listings to display (default: 20).")
+    parser.add_argument("--skip-cache", action="store_true", help="Ignore cache and refresh all sources.")
+    parser.add_argument(
+        "--cache-ttl",
+        type=int,
+        default=60 * 60,
+        help="Cache lifetime in seconds (default: 3600).",
+    )
+    parser.add_argument(
+        "--cache-path",
+        type=Path,
+        default=Path.home() / ".distressed_land_cache.json",
+        help="Path for cached listings.",
+    )
+    parser.add_argument("--export", type=Path, help="Export filtered listings to a CSV file.")
+    parser.add_argument("--interactive", action="store_true", help="Enable interactive detail viewer.")
+    parser.add_argument("--demo", action="store_true", help="Use bundled demo data instead of fetching live data.")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging output.")
+    return parser.parse_args()
+
+
+def export_to_csv(listings: Iterable[PropertyListing], destination: Path) -> None:
+    import csv
+
+    fieldnames = [
+        "source",
+        "external_id",
+        "title",
+        "url",
+        "state",
+        "county",
+        "city",
+        "address",
+        "zip_code",
+        "sale_date",
+        "sale_type",
+        "status",
+        "minimum_bid",
+        "current_bid",
+        "deposit",
+        "acreage",
+        "property_type",
+        "tags",
+    ]
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for listing in listings:
+            row = listing.to_dict()
+            row["tags"] = ", ".join(listing.tags)
+            row["sale_date"] = listing.sale_date.isoformat() if listing.sale_date else ""
+            writer.writerow({field: row.get(field, "") for field in fieldnames})
+
+
+def interactive_loop(scored: List[tuple[int, float, PropertyListing, object]]) -> None:
+    index_lookup: Dict[int, PropertyListing] = {idx: listing for idx, _, listing, _ in scored}
+    print("Enter a listing number to view details, 'r' to refresh filters, or 'q' to quit.")
+    while True:
+        selection = input("Command> ").strip().lower()
+        if selection in {"q", "quit", "exit"}:
+            break
+        if selection in {"r", "refresh"}:
+            print("Interactive refresh not implemented. Rerun the script with different filters.")
+            continue
+        if selection.isdigit():
+            idx = int(selection)
+            listing = index_lookup.get(idx)
+            if not listing:
+                print(f"Listing {idx} not in the current results.")
+                continue
+            scored_entry = next(item for item in scored if item[0] == idx)
+            detail = describe_listing(scored_entry[3])
+            print("\n" + detail + "\n")
+        else:
+            print("Unknown command. Enter listing number, 'r', or 'q'.")
+
+
+def _build_scored_mapping(score_results):
+    scored: List[tuple[int, float, PropertyListing, object]] = []
+    for idx, result in enumerate(score_results, start=1):
+        scored.append((idx, result.score, result.listing, result))
+    return scored
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING, format="%(levelname)s: %(message)s")
+
+    selected_sources = [slug.strip() for slug in args.sources.split(",") if slug.strip()]
+    available_sources = set(SOURCES_REGISTRY.keys())
+    missing_selected = [slug for slug in selected_sources if slug not in available_sources]
+    if missing_selected:
+        for slug in missing_selected:
+            message = MISSING_CONNECTORS.get(slug) or f"Unknown source '{slug}'"
+            logging.warning(message)
+        selected_sources = [slug for slug in selected_sources if slug in available_sources]
+    if not selected_sources and not args.demo:
+        print("No data sources are available. Install optional dependencies such as beautifulsoup4 or use --demo.")
+        return
+    cache = CacheManager(args.cache_path)
+
+    if args.demo:
+        listings = _load_demo_listings()
+    else:
+        listings = fetch_all_sources(selected_sources, cache=cache, ttl=args.cache_ttl, use_cache=not args.skip_cache)
+
+    criteria = FilterCriteria(
+        max_price=args.max_price,
+        min_acreage=args.min_acreage,
+        counties=args.counties,
+        sale_types=args.sale_types,
+        tags=args.tags,
+        keywords=args.keywords,
+    )
+    filtered = apply_filters(listings, criteria)
+    score_results = score_listings(filtered)
+
+    render(score_results, limit=args.limit)
+
+    if args.export:
+        export_to_csv((result.listing for result in score_results), args.export)
+        print(f"Exported {len(score_results)} listings to {args.export}")
+
+    if args.interactive:
+        scored_mapping = _build_scored_mapping(score_results)
+        interactive_loop(scored_mapping)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/distressed_land_finder/demo_data/demo_listings.json
+++ b/distressed_land_finder/demo_data/demo_listings.json
@@ -1,0 +1,75 @@
+[
+  {
+    "source": "IRS Seized Real Estate",
+    "external_id": "fl_miami_warehouse",
+    "title": "Miami Industrial Flex Warehouse",
+    "url": "https://www.treasury.gov/auctions/irs/fl_miami_warehouse.htm",
+    "state": "FL",
+    "county": "Miami-Dade",
+    "city": "Miami",
+    "address": "1250 NW 23rd Street",
+    "zip_code": "33142",
+    "sale_date": "2025-07-15T14:00:00",
+    "sale_type": "Federal seizure auction",
+    "status": "Active",
+    "minimum_bid": 185000.0,
+    "current_bid": null,
+    "deposit": 15000.0,
+    "acreage": 1.7,
+    "property_type": "Commercial Property",
+    "tags": ["IRS", "Seizure", "Federal", "Commercial"],
+    "description": "Warehouse space zoned IU-2 near Port of Miami. Includes fenced laydown yard and two grade-level loading bays.",
+    "raw_data": {
+      "source": "demo",
+      "page_url": "https://www.treasury.gov/auctions/irs/fl_miami_warehouse.htm"
+    }
+  },
+  {
+    "source": "Bid4Assets Florida County Auctions",
+    "external_id": "703219",
+    "title": "Duval County Tax Deed: Vacant Commercial Lot",
+    "url": "https://www.bid4assets.com/auction/703219",
+    "state": "FL",
+    "county": "Duval",
+    "city": "Jacksonville",
+    "address": "0 W Beaver St",
+    "zip_code": "32254",
+    "sale_date": "2025-06-22T10:00:00",
+    "sale_type": "County tax deed auction",
+    "status": "Active",
+    "minimum_bid": 32000.0,
+    "current_bid": 32000.0,
+    "deposit": null,
+    "acreage": 0.92,
+    "property_type": "Vacant Land",
+    "tags": ["Bid4Assets", "Tax Deed"],
+    "description": "Corner lot zoned CC-G allowing light industrial and retail. Close proximity to I-95 corridor.",
+    "raw_data": {
+      "source": "demo"
+    }
+  },
+  {
+    "source": "Bid4Assets Florida County Auctions",
+    "external_id": "705884",
+    "title": "Polk County Tax Lien: Rural Acreage",
+    "url": "https://www.bid4assets.com/auction/705884",
+    "state": "FL",
+    "county": "Polk",
+    "city": "Frostproof",
+    "address": "TBD Sand Ridge Rd",
+    "zip_code": "33843",
+    "sale_date": "2025-05-18T09:00:00",
+    "sale_type": "County tax lien auction",
+    "status": "Active",
+    "minimum_bid": 12500.0,
+    "current_bid": 12500.0,
+    "deposit": null,
+    "acreage": 5.4,
+    "property_type": "Vacant Land",
+    "tags": ["Bid4Assets", "Tax Deed", "Tax Lien"],
+    "description": "Rolling pasture with electric nearby. Agricultural zoning allows small agribusiness operations.",
+    "raw_data": {
+      "source": "demo"
+    }
+  }
+]

--- a/distressed_land_finder/display.py
+++ b/distressed_land_finder/display.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Optional
+
+from .filters import ScoreResult
+
+try:
+    from rich.console import Console
+    from rich.table import Table
+    from rich.text import Text
+except ImportError:  # pragma: no cover - runtime fallback
+    Console = None  # type: ignore
+    Table = None  # type: ignore
+    Text = None  # type: ignore
+
+
+def _format_currency(value: Optional[float]) -> str:
+    if value is None:
+        return "—"
+    return f"$ {value:,.0f}"
+
+
+def _format_date(value: Optional[datetime]) -> str:
+    if value is None:
+        return "—"
+    return value.strftime("%Y-%m-%d")
+
+
+def render(results: Iterable[ScoreResult], *, limit: int = 20) -> None:
+    results_list = list(results)[:limit]
+    if not results_list:
+        print("No listings found that match your criteria.")
+        return
+
+    if Console and Table:
+        console = Console()
+        table = Table(title=f"Top {len(results_list)} Florida distressed land opportunities")
+        table.add_column("#", justify="right")
+        table.add_column("Score", justify="right")
+        table.add_column("Title", overflow="fold")
+        table.add_column("County")
+        table.add_column("Sale Date")
+        table.add_column("Min Bid")
+        table.add_column("Acreage", justify="right")
+        table.add_column("Source")
+        for idx, result in enumerate(results_list, start=1):
+            listing = result.listing
+            acreage = f"{listing.acreage:.2f}" if listing.acreage is not None else "—"
+            score_text = f"{result.score:.1f}"
+            title_text = Text(listing.title)
+            if "seiz" in (listing.sale_type or "").lower():
+                title_text.stylize("bold yellow")
+            if any(tag.lower() == "irs" for tag in listing.tags):
+                title_text.stylize("underline")
+            table.add_row(
+                str(idx),
+                score_text,
+                title_text,
+                listing.county or listing.city or "—",
+                _format_date(listing.sale_date),
+                _format_currency(listing.minimum_bid),
+                acreage,
+                listing.source,
+            )
+        console.print(table)
+    else:
+        print(f"Top {len(results_list)} Florida distressed land opportunities:")
+        print("# | Score | Sale Date | Min Bid | Acres | County | Title")
+        print("-" * 96)
+        for idx, result in enumerate(results_list, start=1):
+            listing = result.listing
+            score = f"{result.score:5.1f}"
+            sale_date = _format_date(listing.sale_date)
+            min_bid = _format_currency(listing.minimum_bid)
+            acreage = f"{listing.acreage:.2f}" if listing.acreage is not None else "—"
+            county = (listing.county or listing.city or "—")[:14]
+            title = listing.title[:60]
+            print(f"{idx:>2} | {score} | {sale_date:>10} | {min_bid:>10} | {acreage:>5} | {county:<14} | {title}")
+
+    print("\nTip: run with --interactive to deep-dive into individual listings.")
+
+
+def describe_listing(result: ScoreResult) -> str:
+    listing = result.listing
+    parts = [
+        f"Title       : {listing.title}",
+        f"Source      : {listing.source}",
+        f"External ID : {listing.external_id}",
+        f"URL         : {listing.url}",
+        f"Sale Type   : {listing.sale_type or '—'}",
+        f"Sale Date   : {_format_date(listing.sale_date)}",
+        f"Location    : {listing.address or '—'}, {listing.city or '—'}, {listing.county or '—'}, {listing.state}",
+        f"Zip Code    : {listing.zip_code or '—'}",
+        f"Minimum Bid : {_format_currency(listing.minimum_bid)}",
+        f"Current Bid : {_format_currency(listing.current_bid)}",
+        f"Deposit Req.: {_format_currency(listing.deposit)}",
+        f"Acreage     : {listing.acreage if listing.acreage is not None else '—'}",
+        f"Property Type: {listing.property_type or '—'}",
+        f"Status      : {listing.status or '—'}",
+        f"Tags        : {', '.join(listing.tags) if listing.tags else '—'}",
+        f"Score       : {result.score:.1f}",
+        "Score Notes :" + ("\n  - " + "\n  - ".join(result.reasons) if result.reasons else " —"),
+        "Description :",
+        f"  {(listing.description or 'No description provided.').strip()}",
+    ]
+    return "\n".join(parts)

--- a/distressed_land_finder/filters.py
+++ b/distressed_land_finder/filters.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from .sources.base import PropertyListing
+
+
+@dataclass(slots=True)
+class FilterCriteria:
+    max_price: Optional[float] = None
+    min_acreage: Optional[float] = None
+    counties: Optional[List[str]] = None
+    sale_types: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
+    include_pending: bool = False
+    keywords: Optional[List[str]] = None
+
+
+def apply_filters(listings: Iterable[PropertyListing], criteria: FilterCriteria) -> List[PropertyListing]:
+    def matches(listing: PropertyListing) -> bool:
+        if criteria.max_price is not None and listing.minimum_bid is not None:
+            if listing.minimum_bid > criteria.max_price:
+                return False
+        if criteria.min_acreage is not None and listing.acreage is not None:
+            if listing.acreage < criteria.min_acreage:
+                return False
+        if criteria.counties:
+            normalized = {c.strip().lower() for c in criteria.counties if c}
+            if normalized and (listing.county or "").lower() not in normalized:
+                return False
+        if criteria.sale_types:
+            normalized_sale_types = {s.lower() for s in criteria.sale_types}
+            sale_type = (listing.sale_type or "").lower()
+            if normalized_sale_types and sale_type not in normalized_sale_types:
+                return False
+        if not criteria.include_pending:
+            status = (listing.status or "").lower()
+            if status in {"cancelled", "canceled", "sold", "redeemed"}:
+                return False
+        if criteria.tags:
+            normalized_tags = {tag.lower() for tag in criteria.tags}
+            listing_tags = {tag.lower() for tag in listing.tags}
+            if not normalized_tags.intersection(listing_tags):
+                return False
+        if criteria.keywords:
+            haystack = " ".join(
+                part.lower()
+                for part in [
+                    listing.title,
+                    listing.description,
+                    listing.address,
+                    listing.city,
+                    listing.county,
+                ]
+                if part
+            )
+            for keyword in criteria.keywords:
+                if keyword.lower() not in haystack:
+                    return False
+        return True
+
+    return [listing for listing in listings if matches(listing)]
+
+
+@dataclass(slots=True)
+class ScoreResult:
+    listing: PropertyListing
+    score: float
+    reasons: List[str]
+
+
+def score_listings(listings: Iterable[PropertyListing], *, reference_date: Optional[datetime] = None) -> List[ScoreResult]:
+    ref = reference_date or datetime.utcnow()
+    results: List[ScoreResult] = []
+    for listing in listings:
+        score = 0.0
+        reasons: List[str] = []
+
+        if listing.minimum_bid is not None and listing.minimum_bid >= 0:
+            # Reward lower bids; clamp around $300k.
+            normalized = max(0.0, min(1.0, (300_000 - listing.minimum_bid) / 300_000))
+            bid_points = normalized * 45
+            if bid_points:
+                reasons.append(f"Lower minimum bid bonus (+{bid_points:.1f})")
+            score += bid_points
+        else:
+            reasons.append("Unknown minimum bid")
+
+        if listing.acreage is not None and listing.acreage > 0:
+            acreage_points = min(listing.acreage, 20) / 20 * 25
+            reasons.append(f"Acreage weight (+{acreage_points:.1f})")
+            score += acreage_points
+
+        if listing.sale_date:
+            delta = (listing.sale_date - ref).days
+            if delta >= 0:
+                urgency_points = max(0.0, min(1.0, (60 - delta) / 60)) * 15
+                if urgency_points:
+                    reasons.append(f"Upcoming sale urgency (+{urgency_points:.1f})")
+                score += urgency_points
+            else:
+                reasons.append("Sale date in the past")
+        else:
+            reasons.append("Unknown sale date")
+
+        if listing.property_type:
+            lowered = listing.property_type.lower()
+            if "commercial" in lowered:
+                score += 8
+                reasons.append("Commercial designation (+8.0)")
+            if any(keyword in lowered for keyword in ["land", "lot", "acre"]):
+                score += 6
+                reasons.append("Vacant land keyword (+6.0)")
+
+        if listing.sale_type:
+            lowered = listing.sale_type.lower()
+            if "tax" in lowered or "deed" in lowered or "lien" in lowered:
+                score += 4
+                reasons.append("Tax delinquency sale (+4.0)")
+            if "seiz" in lowered or "federal" in lowered:
+                score += 4
+                reasons.append("Seizure sale (+4.0)")
+
+        if listing.tags:
+            tag_bonus = min(len(listing.tags), 5)
+            if tag_bonus:
+                score += tag_bonus
+                reasons.append(f"Source tags (+{tag_bonus:.1f})")
+
+        results.append(ScoreResult(listing=listing, score=score, reasons=reasons))
+
+    results.sort(key=lambda item: item.score, reverse=True)
+    return results

--- a/distressed_land_finder/http.py
+++ b/distressed_land_finder/http.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+
+DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/json,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Connection": "keep-alive",
+}
+
+
+class HttpClient:
+    def __init__(self, timeout: int = 20) -> None:
+        self.session = requests.Session()
+        self.session.headers.update(DEFAULT_HEADERS)
+        self.timeout = timeout
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def get(self, url: str, *, params: Optional[dict] = None) -> requests.Response:
+        self.log.debug("GET %s params=%s", url, params)
+        response = self.session.get(url, params=params, timeout=self.timeout)
+        response.raise_for_status()
+        return response
+
+    def get_json(self, url: str, *, params: Optional[dict] = None) -> dict:
+        resp = self.get(url, params=params)
+        return resp.json()

--- a/distressed_land_finder/requirements.txt
+++ b/distressed_land_finder/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+python-dateutil
+rich

--- a/distressed_land_finder/sources/base.py
+++ b/distressed_land_finder/sources/base.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Protocol
+
+
+@dataclass(slots=True)
+class PropertyListing:
+    """Normalized representation of a distressed property listing."""
+
+    source: str
+    external_id: str
+    title: str
+    url: str
+    state: str
+    county: Optional[str] = None
+    city: Optional[str] = None
+    address: Optional[str] = None
+    zip_code: Optional[str] = None
+    sale_date: Optional[datetime] = None
+    sale_type: Optional[str] = None
+    status: Optional[str] = None
+    minimum_bid: Optional[float] = None
+    current_bid: Optional[float] = None
+    deposit: Optional[float] = None
+    acreage: Optional[float] = None
+    property_type: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    description: Optional[str] = None
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the listing to a serializable dictionary."""
+
+        data: Dict[str, Any] = {
+            "source": self.source,
+            "external_id": self.external_id,
+            "title": self.title,
+            "url": self.url,
+            "state": self.state,
+            "county": self.county,
+            "city": self.city,
+            "address": self.address,
+            "zip_code": self.zip_code,
+            "sale_date": self.sale_date.isoformat() if self.sale_date else None,
+            "sale_type": self.sale_type,
+            "status": self.status,
+            "minimum_bid": self.minimum_bid,
+            "current_bid": self.current_bid,
+            "deposit": self.deposit,
+            "acreage": self.acreage,
+            "property_type": self.property_type,
+            "tags": self.tags,
+            "description": self.description,
+            "raw_data": self.raw_data,
+        }
+        return data
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "PropertyListing":
+        sale_date_raw = payload.get("sale_date")
+        sale_date = None
+        if sale_date_raw:
+            try:
+                sale_date = datetime.fromisoformat(sale_date_raw)
+            except ValueError:
+                sale_date = None
+        return cls(
+            source=payload["source"],
+            external_id=payload["external_id"],
+            title=payload["title"],
+            url=payload["url"],
+            state=payload.get("state", ""),
+            county=payload.get("county"),
+            city=payload.get("city"),
+            address=payload.get("address"),
+            zip_code=payload.get("zip_code"),
+            sale_date=sale_date,
+            sale_type=payload.get("sale_type"),
+            status=payload.get("status"),
+            minimum_bid=payload.get("minimum_bid"),
+            current_bid=payload.get("current_bid"),
+            deposit=payload.get("deposit"),
+            acreage=payload.get("acreage"),
+            property_type=payload.get("property_type"),
+            tags=list(payload.get("tags", [])),
+            description=payload.get("description"),
+            raw_data=dict(payload.get("raw_data", {})),
+        )
+
+
+class AuctionSource(Protocol):
+    slug: str
+    title: str
+
+    def fetch_listings(self) -> Iterable[PropertyListing]:
+        ...
+
+
+def merge_tags(*tag_groups: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    merged: List[str] = []
+    for group in tag_groups:
+        for tag in group:
+            normalized = tag.strip().lower()
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                merged.append(tag)
+    return merged

--- a/distressed_land_finder/sources/bid4assets.py
+++ b/distressed_land_finder/sources/bid4assets.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Optional
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+from dateutil import parser as date_parser
+
+from ..http import HttpClient
+from .base import PropertyListing, merge_tags
+
+
+@dataclass
+class _RawBid4AssetsListing:
+    identifier: str
+    title: str
+    url: str
+    minimum_bid: Optional[float]
+    current_bid: Optional[float]
+    city: Optional[str]
+    county: Optional[str]
+    state: str
+    sale_date: Optional[datetime]
+    sale_type: Optional[str]
+    acreage: Optional[float]
+    property_type: Optional[str]
+    status: Optional[str]
+    description: Optional[str]
+
+
+class Bid4AssetsFloridaSource:
+    slug = "bid4assets"
+    title = "Bid4Assets Florida County Auctions"
+
+    BASE_URL = "https://www.bid4assets.com/"
+    SEARCH_PATH = "mvc/listing"
+
+    def __init__(self, *, client: Optional[HttpClient] = None) -> None:
+        self.client = client or HttpClient()
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def fetch_listings(self) -> Iterable[PropertyListing]:
+        html = self._fetch_listing_page()
+        raw_listings = self._parse_raw_listings(html)
+        listings: List[PropertyListing] = []
+        for raw in raw_listings:
+            tags = ["Bid4Assets", "Tax Deed"]
+            if raw.property_type and "commercial" in raw.property_type.lower():
+                tags.append("Commercial")
+            if raw.sale_type and "lien" in raw.sale_type.lower():
+                tags.append("Tax Lien")
+            listing = PropertyListing(
+                source=self.title,
+                external_id=raw.identifier,
+                title=raw.title,
+                url=raw.url,
+                state=raw.state,
+                county=raw.county,
+                city=raw.city,
+                sale_date=raw.sale_date,
+                sale_type=raw.sale_type or "County tax deed auction",
+                status=raw.status or "Active",
+                minimum_bid=raw.minimum_bid,
+                current_bid=raw.current_bid,
+                acreage=raw.acreage,
+                property_type=raw.property_type,
+                description=raw.description,
+                tags=merge_tags(tags),
+                raw_data={"source": "bid4assets"},
+            )
+            listings.append(listing)
+        return listings
+
+    def _fetch_listing_page(self) -> str:
+        params = {
+            "state": "FL",
+            "upcoming": "true",
+            "category": "Real Estate",
+            "type": "upcoming",
+        }
+        try:
+            response = self.client.get(urljoin(self.BASE_URL, self.SEARCH_PATH), params=params)
+        except Exception as exc:  # pragma: no cover - network failure
+            self.log.warning("Unable to fetch Bid4Assets listings: %s", exc)
+            return ""
+        return response.text
+
+    def _parse_raw_listings(self, html: str) -> List[_RawBid4AssetsListing]:
+        if not html:
+            return []
+        soup = BeautifulSoup(html, "html.parser")
+        # Attempt to parse JSON embedded in script tags (Nuxt / Angular style)
+        for script in soup.find_all("script"):
+            if not script.string:
+                continue
+            if "__NUXT__" in script.string:
+                json_data = self._extract_nuxt_payload(script.string)
+                if json_data:
+                    listings = self._parse_from_json(json_data)
+                    if listings:
+                        return listings
+        # Fallback to parsing HTML tiles
+        return self._parse_from_tiles(soup)
+
+    def _extract_nuxt_payload(self, script_text: str) -> Optional[dict]:
+        match = re.search(r"__NUXT__\s*=\s*(\{.*\})", script_text, re.DOTALL)
+        if not match:
+            return None
+        raw = match.group(1)
+        # Remove trailing semicolon or script closing tags
+        raw = raw.rstrip(";\n ")
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+    def _parse_from_json(self, payload: dict) -> List[_RawBid4AssetsListing]:  # pragma: no cover - depends on live payload
+        listings: List[_RawBid4AssetsListing] = []
+        items = self._walk_for_key(payload, "listings")
+        for item in items:
+            if not isinstance(item, list):
+                continue
+            for entry in item:
+                listing = self._build_listing_from_json(entry)
+                if listing:
+                    listings.append(listing)
+        return listings
+
+    def _walk_for_key(self, payload: dict, key: str) -> List[object]:
+        matches: List[object] = []
+        stack = [payload]
+        while stack:
+            current = stack.pop()
+            if isinstance(current, dict):
+                for k, value in current.items():
+                    if k == key:
+                        matches.append(value)
+                    if isinstance(value, (dict, list)):
+                        stack.append(value)
+            elif isinstance(current, list):
+                stack.extend(current)
+        return matches
+
+    def _build_listing_from_json(self, entry: dict) -> Optional[_RawBid4AssetsListing]:
+        try:
+            identifier = str(entry.get("auctionId") or entry.get("id") or entry.get("auctionid"))
+            if not identifier or identifier == "None":
+                return None
+            title = entry.get("title") or entry.get("name") or "Bid4Assets Listing"
+            url_path = entry.get("url") or entry.get("href") or entry.get("link")
+            if url_path:
+                url = urljoin(self.BASE_URL, url_path)
+            else:
+                url = urljoin(self.BASE_URL, f"auction/{identifier}")
+            minimum_bid = self._to_float(entry.get("minimumBid") or entry.get("minBid") or entry.get("startBid"))
+            current_bid = self._to_float(entry.get("currentBid") or entry.get("currentBidAmount"))
+            city = self._strip(entry.get("city"))
+            county = self._strip(entry.get("county"))
+            state = (entry.get("state") or "FL").upper()
+            sale_date = self._parse_date(entry.get("startDate") or entry.get("saleDate"))
+            sale_type = self._strip(entry.get("auctionType") or entry.get("saleType"))
+            acreage = self._to_float(entry.get("acreage") or entry.get("lotSize"))
+            property_type = self._strip(entry.get("propertyType") or entry.get("category"))
+            status = self._strip(entry.get("status"))
+            description = self._strip(entry.get("description"))
+            return _RawBid4AssetsListing(
+                identifier=identifier,
+                title=title,
+                url=url,
+                minimum_bid=minimum_bid,
+                current_bid=current_bid,
+                city=city,
+                county=county,
+                state=state,
+                sale_date=sale_date,
+                sale_type=sale_type,
+                acreage=acreage,
+                property_type=property_type,
+                status=status,
+                description=description,
+            )
+        except Exception as exc:
+            self.log.debug("Unable to parse Bid4Assets JSON entry: %s", exc)
+            return None
+
+    def _parse_from_tiles(self, soup: BeautifulSoup) -> List[_RawBid4AssetsListing]:
+        listings: List[_RawBid4AssetsListing] = []
+        cards = soup.select("[data-auction-id]")
+        for card in cards:
+            identifier = card.get("data-auction-id")
+            if not identifier:
+                continue
+            title_el = card.select_one(".auction-title, .title, h3, h4")
+            title = title_el.get_text(strip=True) if title_el else "Bid4Assets Auction"
+            href_el = card.find("a", href=True)
+            url = urljoin(self.BASE_URL, href_el["href"]) if href_el else urljoin(self.BASE_URL, f"auction/{identifier}")
+            city = self._strip(card.get("data-city"))
+            county = self._strip(card.get("data-county"))
+            state = (card.get("data-state") or "FL").upper()
+            sale_date = self._parse_date(card.get("data-start-date") or card.get("data-sale-date"))
+            sale_type = self._strip(card.get("data-sale-type") or card.get("data-auction-type"))
+            acreage = self._to_float(card.get("data-acreage") or card.get("data-lot-size"))
+            min_bid_text = card.get("data-minimum-bid") or card.get("data-minbid")
+            minimum_bid = self._to_float(min_bid_text)
+            current_bid = self._to_float(card.get("data-current-bid"))
+            property_type = self._strip(card.get("data-property-type"))
+            status = self._strip(card.get("data-status"))
+            description_el = card.select_one(".auction-description, .description")
+            description = description_el.get_text(" ", strip=True) if description_el else None
+            listings.append(
+                _RawBid4AssetsListing(
+                    identifier=identifier,
+                    title=title,
+                    url=url,
+                    minimum_bid=minimum_bid,
+                    current_bid=current_bid,
+                    city=city,
+                    county=county,
+                    state=state,
+                    sale_date=sale_date,
+                    sale_type=sale_type,
+                    acreage=acreage,
+                    property_type=property_type,
+                    status=status,
+                    description=description,
+                )
+            )
+        return listings
+
+    def _strip(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        value = str(value).strip()
+        return value or None
+
+    def _to_float(self, value: Optional[str | float | int]) -> Optional[float]:
+        if value in (None, "", "None"):
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        value_str = str(value)
+        match = re.search(r"([0-9]+(?:\.[0-9]+)?)", value_str.replace(",", ""))
+        if match:
+            try:
+                return float(match.group(1))
+            except ValueError:
+                return None
+        return None
+
+    def _parse_date(self, value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return date_parser.parse(str(value), fuzzy=True)
+        except (ValueError, OverflowError):
+            return None

--- a/distressed_land_finder/sources/irs.py
+++ b/distressed_land_finder/sources/irs.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import Iterable, List, Optional
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+from dateutil import parser as date_parser
+
+from ..http import HttpClient
+from .base import PropertyListing, merge_tags
+
+
+class IRSRealEstateSource:
+    slug = "irs"
+    title = "IRS Seized Real Estate"
+
+    BASE_URL = "https://www.treasury.gov/auctions/irs/"
+    INDEX_PAGES = [
+        urljoin(BASE_URL, "auctions1.shtml"),
+        urljoin(BASE_URL, "auctions2.shtml"),
+    ]
+
+    def __init__(self, *, client: Optional[HttpClient] = None, state: str = "FL") -> None:
+        self.client = client or HttpClient()
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.state = state.upper()
+
+    def fetch_listings(self) -> Iterable[PropertyListing]:
+        detail_urls = self._discover_state_urls()
+        listings: List[PropertyListing] = []
+        for url in sorted(detail_urls):
+            try:
+                listing = self._parse_listing(url)
+            except Exception as exc:  # pragma: no cover - best-effort network parsing
+                self.log.warning("Failed to parse IRS listing at %s: %s", url, exc)
+                continue
+            if listing:
+                listings.append(listing)
+        return listings
+
+    def _discover_state_urls(self) -> List[str]:
+        pattern = re.compile(rf"\b{self.state}\b", re.IGNORECASE)
+        urls: set[str] = set()
+        for index_url in self.INDEX_PAGES:
+            try:
+                html = self.client.get(index_url).text
+            except Exception as exc:  # pragma: no cover - network failure
+                self.log.warning("Unable to fetch IRS index %s: %s", index_url, exc)
+                continue
+            soup = BeautifulSoup(html, "html.parser")
+            for link in soup.find_all("a", href=True):
+                href = link["href"].strip()
+                text = " ".join(link.stripped_strings)
+                if not href.lower().endswith((".htm", ".html")):
+                    continue
+                if pattern.search(text) or self.state.lower() in href.lower():
+                    urls.add(urljoin(self.BASE_URL, href))
+        return list(urls)
+
+    def _parse_listing(self, url: str) -> Optional[PropertyListing]:
+        response = self.client.get(url)
+        soup = BeautifulSoup(response.text, "html.parser")
+        title = self._extract_title(soup, url)
+        raw_text = "\n".join(soup.stripped_strings)
+
+        sale_date = self._extract_date(raw_text)
+        minimum_bid = self._extract_currency(raw_text, ["Minimum Bid", "Min Bid"])
+        deposit = self._extract_currency(raw_text, ["Deposit", "Minimum Deposit"])
+        address, city, county, zip_code = self._extract_location(raw_text)
+        acreage = self._extract_acreage(raw_text)
+        property_type = self._guess_property_type(title, raw_text)
+        description = self._extract_description(soup)
+
+        tags = merge_tags(["IRS"], ["Seizure"], ["Federal"], ["Commercial" if "commercial" in (property_type or "").lower() else ""])
+        tags = [tag for tag in tags if tag]
+
+        external_id = self._extract_external_id(url)
+
+        return PropertyListing(
+            source=self.title,
+            external_id=external_id,
+            title=title,
+            url=url,
+            state=self.state,
+            county=county,
+            city=city,
+            address=address,
+            zip_code=zip_code,
+            sale_date=sale_date,
+            sale_type="Federal seizure auction",
+            status="Active",
+            minimum_bid=minimum_bid,
+            deposit=deposit,
+            acreage=acreage,
+            property_type=property_type,
+            tags=tags,
+            description=description,
+            raw_data={"source": "irs", "page_url": url},
+        )
+
+    def _extract_title(self, soup: BeautifulSoup, url: str) -> str:
+        title_el = soup.find("h1") or soup.find("h2")
+        if title_el:
+            return title_el.get_text(strip=True)
+        strong_el = soup.find("strong")
+        if strong_el:
+            return strong_el.get_text(strip=True)
+        return f"IRS Auction - {url.split('/')[-1]}"
+
+    def _extract_date(self, text: str) -> Optional[datetime]:
+        match = re.search(r"Sale Date(?: & Time)?:\s*([^\n]+)", text, re.IGNORECASE)
+        if not match:
+            match = re.search(r"Date:\s*([^\n]+)", text, re.IGNORECASE)
+        if match:
+            candidate = match.group(1).strip()
+            try:
+                return date_parser.parse(candidate, fuzzy=True)
+            except (ValueError, OverflowError):
+                return None
+        return None
+
+    def _extract_currency(self, text: str, labels: List[str]) -> Optional[float]:
+        for label in labels:
+            pattern = re.compile(rf"{label}[^$]*\$([0-9,]+(?:\.[0-9]+)?)", re.IGNORECASE)
+            match = pattern.search(text)
+            if match:
+                raw = match.group(1)
+                try:
+                    return float(raw.replace(",", ""))
+                except ValueError:
+                    continue
+        return None
+
+    def _extract_location(self, text: str) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+        match = re.search(r"Property (?:Location|Address):\s*([^\n]+)", text, re.IGNORECASE)
+        address_line = match.group(1).strip() if match else None
+        city = county = zip_code = None
+        if address_line:
+            parts = [part.strip() for part in re.split(r",| - ", address_line) if part.strip()]
+            if parts:
+                city = parts[-2] if len(parts) >= 2 else parts[-1]
+                if "FL" in parts[-1]:
+                    zip_match = re.search(r"(\d{5})", parts[-1])
+                    zip_code = zip_match.group(1) if zip_match else None
+                county_match = re.search(r"([A-Za-z]+) County", text)
+                if county_match:
+                    county = county_match.group(1).strip()
+            address_line = ", ".join(parts)
+        return address_line, city, county, zip_code
+
+    def _extract_acreage(self, text: str) -> Optional[float]:
+        match = re.search(r"([0-9]+(?:\.[0-9]+)?)\s*(?:acre|acres)\b", text, re.IGNORECASE)
+        if match:
+            try:
+                return float(match.group(1))
+            except ValueError:
+                return None
+        return None
+
+    def _guess_property_type(self, title: str, text: str) -> Optional[str]:
+        combined = f"{title}\n{text}".lower()
+        if "commercial" in combined:
+            return "Commercial Property"
+        if "industrial" in combined:
+            return "Industrial Property"
+        if any(word in combined for word in ["vacant", "land", "lot", "acre"]):
+            return "Vacant Land"
+        if "residential" in combined:
+            return "Residential"
+        return None
+
+    def _extract_description(self, soup: BeautifulSoup) -> Optional[str]:
+        paragraphs = [p.get_text(" ", strip=True) for p in soup.find_all("p")]
+        if not paragraphs:
+            paragraphs = [soup.get_text(" ", strip=True)]
+        return "\n".join(paragraphs[:5]) if paragraphs else None
+
+    def _extract_external_id(self, url: str) -> str:
+        match = re.search(r"([a-z0-9]+)\.htm", url, re.IGNORECASE)
+        if match:
+            return match.group(1)
+        return url


### PR DESCRIPTION
## Summary
- add a `distressed_land_finder` package that aggregates Florida IRS seizure auctions and county tax deed listings from Bid4Assets with filtering, scoring, and interactive review
- build supporting HTTP, caching, display, and scoring utilities plus a bundled demo dataset and usage documentation tailored for iSH users
- provide dependency metadata for the new toolkit

## Testing
- python -m compileall distressed_land_finder
- python -m distressed_land_finder.cli --demo --limit 2 --verbose


------
https://chatgpt.com/codex/tasks/task_e_68d260a27a9c832db1cfad2ae18c62e9